### PR TITLE
Update GA tracker on each page view

### DIFF
--- a/src/targets/google-analytics/google-analytics.js
+++ b/src/targets/google-analytics/google-analytics.js
@@ -1,5 +1,10 @@
 function GoogleAnalytics(events) {
-  events.forEach((event) => { window.ga('send', event); });
+  events.forEach((event) => {
+    if (event.hitType === 'pageview') {
+      window.ga('set', 'page', event.page);
+    }
+    window.ga('send', event);
+  });
 }
 
 module.exports = { GoogleAnalytics };

--- a/test/targets/google-analytics.js
+++ b/test/targets/google-analytics.js
@@ -30,5 +30,20 @@ describe('Target: Google Analytics', () => {
       expect(window.ga).toHaveBeenCalledWith('send', events[0]);
       expect(window.ga).toHaveBeenCalledWith('send', events[1]);
     });
+    describe('on a page view hit', () => {
+      it('updates the tracker window.ga("set", "page", ...)', () => {
+        const events = [
+          {
+            hitType: 'pageview',
+            page: '/home',
+          },
+        ];
+
+        window.ga = jest.fn();
+        GoogleAnalytics(events);
+
+        expect(window.ga).toHaveBeenCalledWith('set', 'page', '/home');
+      });
+    });
   });
 });


### PR DESCRIPTION
This is so Google Analytics will know the page you're on when an event happens...not sure what reports this affects...but it is good practice: https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications