### PR TITLE
Adds React Native Amplitude with Expo target

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ events off to a target. Read more about offline event collection in the
  - [Amplitude](https://rangle.github.io/redux-beacon/docs/targets/amplitude.html)
  - [_(React Native)_ Google Analytics](https://rangle.github.io/redux-beacon/docs/targets/react-native-google-analytics.html)
  - [_(React Native)_ Google Tag Manager](https://rangle.github.io/redux-beacon/docs/targets/react-native-google-tag-manager.html)
+ - [_(React Native)_ Amplitude with Expo](https://rangle.github.io/redux-beacon/docs/targets/react-native-amplitude-expo.html)
  - [_(Cordova)_ Google Analytics](https://rangle.github.io/redux-beacon/docs/targets/cordova-google-analytics.html)
 
 ## Docs

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -15,6 +15,7 @@
   * [Amplitude](docs/targets/amplitude.md)
   * [(React Native) Google Analytics](docs/targets/react-native-google-analytics.md)
   * [(React Native) Google Tag Manager](docs/targets/react-native-google-tag-manager.md)
+  * [(React Native) Amplitude with Expo](docs/targets/react-native-amplitude-expo.md)
   * [(Cordova) Google Analytics](docs/targets/cordova-google-analytics.md)
 * [Extensions](docs/extensions/index.md)
   * [logger](docs/extensions/logger.md)

--- a/docs/targets/react-native-amplitude-expo.md
+++ b/docs/targets/react-native-amplitude-expo.md
@@ -1,0 +1,20 @@
+# React Native Amplitude with Expo
+
+### Usage Instructions
+
+1. Sign up for Amplitude if you haven't already, and
+   [create a new project](https://amplitude.zendesk.com/hc/en-us/articles/207108137-Introduction-Getting-Started).
+
+2. Take note of your [Amplitude API key](https://amplitude.zendesk.com/hc/en-us/articles/207108137-Introduction-Getting-Started#getting-started).
+
+3. Create a new [Expo](https://expo.io/learn) project, or [use ExpoKit](https://docs.expo.io/versions/latest/guides/expokit.html) in your project.
+
+4. Import the target, then provide it when creating the middleware:
+
+   ```js
+   import { Amplitude } from 'expo';
+   import { AmplitudeExpo } from 'redux-beacon/targets/react-native';
+
+   const target = AmplitudeExpo('YOUR_API_KEY', AmplitudeExpo);
+   const analyticsMiddleware = createMiddleware(eventsMap, target);
+   ```

--- a/src/targets/react-native/amplitude-expo/amplitude-expo.js
+++ b/src/targets/react-native/amplitude-expo/amplitude-expo.js
@@ -1,0 +1,12 @@
+export function AmplitudeExpo(apiKey, Amplitude) {
+  Amplitude.initialize(apiKey);
+  return function AmplitudeExpoTarget(events) {
+    events.forEach(targetEvent => {
+      const properties = Object.keys(targetEvent)
+        .filter(key => key !== 'event')
+        .reduce((result, key) => (result[key] = obj[key], result), {});
+
+      Amplitude.logEventWithProperties(targetEvent.event, properties);
+    });
+  };
+}

--- a/src/targets/react-native/amplitude-expo/index.js
+++ b/src/targets/react-native/amplitude-expo/index.js
@@ -1,0 +1,1 @@
+export { AmplitudeExpo } from './amplitude-expo';

--- a/src/targets/react-native/index.d.ts
+++ b/src/targets/react-native/index.d.ts
@@ -1,2 +1,3 @@
 export function GoogleAnalytics(trackingId: string, GABridge: any): void;
 export function GoogleTagManager(trackingId: string, GTMBridge: any): void;
+export function AmplitudeExpo(apiKey: string, Amplitude: any): void;

--- a/src/targets/react-native/index.js
+++ b/src/targets/react-native/index.js
@@ -1,7 +1,9 @@
 const { GoogleAnalytics } = require('./google-analytics');
 const { GoogleTagManager } = require('./google-tag-manager');
+const { AmplitudeExpo } = require('./amplitude-expo');
 
 module.exports = {
   GoogleAnalytics,
   GoogleTagManager,
+  AmplitudeExpo,
 };


### PR DESCRIPTION
[Expo](https://expo.io/) has [its own implementation](https://docs.expo.io/versions/latest/sdk/amplitude.html) of Amplitude SDK integration for React Native.

I added a target made specifically for that implementation. I couldn't find contribution guidelines, so I tried my best to keep up with the standards of the project. But please let me know if you need me to change anything.
  