### PR TITLE
Added extra methods to react-native google-analytics

### DIFF
--- a/src/targets/react-native/google-analytics/google-analytics.js
+++ b/src/targets/react-native/google-analytics/google-analytics.js
@@ -22,8 +22,44 @@ export function GoogleAnalytics(trackingId, GoogleAnalyticsTracker) {
           break;
         }
 
+        case 'eventCustomDimensions': {
+          const options = {};
+
+          if (event.eventLabel !== undefined) {
+            options.label = event.eventLabel;
+          }
+          if (event.eventValue !== undefined) {
+            options.value = event.eventValue;
+          }
+
+          if (Object.keys(options).length > 0) {
+            tracker.trackEventWithCustomDimensionValues(
+              event.eventCategory,
+              event.eventAction,
+              options,
+              event.customDimensionDict,
+            );
+          } else {
+            tracker.trackEventWithCustomDimensionValues(
+              event.eventCategory,
+              event.eventAction,
+              {},
+              event.customDimensionDict,
+            );
+          }
+          break;
+        }
+
         case 'pageview': {
           tracker.trackScreenView(event.page);
+          break;
+        }
+
+        case 'pageviewCustomDimensions': {
+          tracker.trackScreenViewWithCustomDimensionValues(
+            event.page,
+            event.customDimensionDict,
+          );
           break;
         }
 
@@ -39,7 +75,7 @@ export function GoogleAnalytics(trackingId, GoogleAnalyticsTracker) {
             tracker.trackTiming(
               event.timingCategory,
               event.timingValue,
-              options
+              options,
             );
           } else {
             tracker.trackTiming(event.timingCategory, event.timingValue);
@@ -51,8 +87,18 @@ export function GoogleAnalytics(trackingId, GoogleAnalyticsTracker) {
           tracker.trackSocialInteraction(
             event.socialNetwork,
             event.socialAction,
-            event.socialTarget
+            event.socialTarget,
           );
+          break;
+        }
+
+        case 'user': {
+          tracker.setUser(event.userId);
+          break;
+        }
+
+        case 'client': {
+          tracker.setClient(event.clientId);
           break;
         }
 


### PR DESCRIPTION
This PR adds the following events to the react-native/google-analytics target, implemented in react-native-google-analytics-bridge as shown here: https://github.com/idehub/react-native-google-analytics-bridge/blob/b009a2713a704126d595b01d74e511202e12b11f/src/GoogleAnalyticsTracker.js

- `eventCustomDimensions`
- `pageviewCustomDimensions`
- `user`
- `client`

We've been using the above in production for a while now and here are some basic usage examples:

**eventCustomDimensions**
With your custom dimensions setup in Google Analytics, this is much the same as a normal `event` just with an added dictionary of your custom data:
```
return {
  hitType: 'eventCustomDimensions',
  eventCategory: 'Auth',
  eventAction: action.type,
  eventLabel: 'Register: Failure',
  customDimensionDict: { 4: errorDetail },
}
```

**pageviewCustomDimensions**
With your custom dimensions setup in Google Analytics, simply add them to the custom dimension dictionary:
```
return {
    hitType: 'pageviewCustomDimensions',
    page: screenName,
    customDimensionDict: { 1: slug, 5: id },
}
```

**user**
```
return {
  hitType: 'user',
  userId: userId,
}
```