### PR TITLE
Adds overloading of first parameter eventsMap of createMiddleware to support function argument

### DIFF
--- a/docs/api/create-middleware.md
+++ b/docs/api/create-middleware.md
@@ -8,7 +8,7 @@ createMiddleware(eventsMap, target[, extensions]);
 
 #### Parameters
 
- * `eventsMap`: [eventsMap](events-map.md)
+ * `eventsMap | eventsFunction`: [eventsMap](events-map.md)
  * `target`: [target](../targets/index.md)
  * `extensions` *(optional)*: [extensions](../extensions/index.md).
 

--- a/docs/api/events-map.md
+++ b/docs/api/events-map.md
@@ -34,3 +34,43 @@ import { EventsMap } from 'redux-beacon';
 ### Usage
  * [Getting Started](../getting-started-redux-users.md)
  * [Examples & Recipes](../recipes/index.md)
+
+## `EventsFunction`
+
+A `Function` you provide to Redux Beacon to map actions
+to Arrays of [eventDefinitions](./event-definition.md).
+
+### Syntax
+
+```js
+import {
+  eventForActionA,
+  eventForActionB,
+  eventForAllActions,
+} from './event-definitions';
+
+const eventsFunction = (action) => {
+  switch(action.type){
+    case 'ACTION_A': 
+      return [eventForActionA];
+    case 'ACTION_B': 
+      return [eventForActionB];
+    default:
+      return [];
+  };
+}
+```
+
+### Rules
+ - Each element in the returned array must be a valid
+   [eventDefinition](./event-definition.md).
+
+### Typescript Type
+
+```ts
+import { EventsFunction } from 'redux-beacon';
+```
+
+### Usage
+ * [Getting Started](../getting-started-redux-users.md)
+ * [Examples & Recipes](../recipes/index.md)

--- a/packages/redux-beacon/src/index.ts
+++ b/packages/redux-beacon/src/index.ts
@@ -7,6 +7,7 @@ export { createMiddleware, createMetaReducer, createEvents };
 export {
   EventDefinition,
   EventsMap,
+  EventsFunction,
   LoggerExtension,
   OfflineStorageExtension,
   Target,

--- a/packages/redux-beacon/src/types.ts
+++ b/packages/redux-beacon/src/types.ts
@@ -12,6 +12,10 @@ export type EventDefinition<E = any> = (
   nextState: any
 ) => E;
 
+export type EventsFunction = (
+  action: { [key: string]: any }
+) => EventDefinition[];
+
 /**
  * A map between your actions and your analytics events.  Each key
  * must be an action type. Each property must be a valid


### PR DESCRIPTION
Checklist
----

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

 - [ ] I have added tests that prove my fix is effective or that my feature works.
 - [x] I have added all necessary documentation (if appropriate)
 - [ ] I have updated the [CHANGELOG](https://github.com/rangle/redux-beacon/blob/master/CHANGELOG.md)

What was done
----

Adds the ability to pass a function as the first argument of `createMiddleware`, that is called with the `action` and is expected to return an array of `EventDefinition`s. 

Why: I want to be able to automatically generate `EventDefinition`s for my actions based on action properties. If you don't see this as useful for others I don't mind this PR being closed, but the downsides seem limited.


Associated Issues
----
None

:heart: Thanks
----
Thanks for taking the time to help out with the project, it's much appreciated :slightly_smiling_face:
