### PR TITLE
fix issue with any other type that was not array

### DIFF
--- a/packages/offline-react-native/src/__tests__/offline-react-native.test.ts
+++ b/packages/offline-react-native/src/__tests__/offline-react-native.test.ts
@@ -46,4 +46,37 @@ describe('When saving events:', () => {
       });
     });
   });
+
+  describe('When purging events', () => {
+    it('returns an empty array when there are no items to be purged', () => {
+      const AsyncStorage = {
+        getItem: () => Promise.resolve(null),
+      };
+      const isConnected = () => {};
+      const purgeEventCallback = oldEvents => oldEvents;
+
+      const extension = offlineReactNative(AsyncStorage, isConnected);
+
+      return extension.purgeEvents(purgeEventCallback).then(oldEvents => {
+        expect(Array.isArray(oldEvents)).toBe(true);
+        expect(oldEvents.length).toBe(0);
+      });
+    });
+    it('returns array of items when there are items to be purged', () => {
+      const sampleEvent = { hitType: 'pageview', page: '/whatever' };
+      const AsyncStorage = {
+        getItem: () => Promise.resolve(JSON.stringify([sampleEvent])),
+      };
+      const isConnected = () => {};
+      const purgeEventCallback = oldEvents => oldEvents;
+
+      const extension = offlineReactNative(AsyncStorage, isConnected);
+
+      return extension.purgeEvents(purgeEventCallback).then(oldEvents => {
+        expect(Array.isArray(oldEvents)).toBe(true);
+        expect(oldEvents.length).toBe(1);
+        expect(oldEvents[0]).toEqual(sampleEvent);
+      });
+    });
+  });
 });

--- a/packages/offline-react-native/src/offline-react-native.ts
+++ b/packages/offline-react-native/src/offline-react-native.ts
@@ -30,6 +30,7 @@ function offlineReactNative(
   const purgeEvents = (handlePurgedEvents: PurgedEventsHandler) =>
     AsyncStorage.getItem(STORE_KEY, () => AsyncStorage.removeItem(STORE_KEY))
       .then(JSON.parse)
+      .then((oldEvents: any[]) => oldEvents || [])
       .then(handlePurgedEvents);
 
   return {


### PR DESCRIPTION
Checklist
----

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

 - [x] I have added tests that prove my fix is effective or that my feature works.
 - [x] I have added all necessary documentation (if appropriate)

What was done
----

I am currently working with react-native + redux-beacon with google analytics.
I just update redux-beacon to the latest version and I found a small issue when using

- `@redux-beacon/offline-react-native`
- `@redux-beacon/react-native-google-analytics`

The problem is that the function isEmptyArray is returning false for any argument that the type is not array, in my case that function was being called with null, so the function isEmptyArray return false then the condition for not (!isEmptyArray) is going to be true, so the code thinks that we have an array and that the array is not empty.

I solve this problem reviewing the other way around that the argument is an array and that it is not empty, for that reason I change the name no isNotEmptyArray and replace is 2 places that were doing a wrong validation.

Associated Issues
----
 - _list any associated issue numbers here_

:heart: Thanks
----
Thanks for taking the time to help out with the project, it's much appreciated :slightly_smiling_face:
