### PR TITLE
Support custom dimensions in GA pageviews and events

### DIFF
--- a/packages/google-analytics/src/__tests__/google-analytics.test.ts
+++ b/packages/google-analytics/src/__tests__/google-analytics.test.ts
@@ -1,4 +1,5 @@
 import GoogleAnalytics from '../';
+import { trackEvent, trackPageView } from '../event-helpers';
 
 beforeEach(() => {
   window.ga = undefined;
@@ -220,6 +221,57 @@ describe('GoogleAnalytics(events)', () => {
 
       target(events);
       expect(window.ga).toHaveBeenCalledWith('ec:setAction', 'click', {});
+    });
+  });
+  describe('When you pass the target an event with a fieldsObject', () => {
+    test('the properties in the field object are included in the ga event hit', () => {
+      const events = [
+        trackEvent(() => ({
+          category: 'event-category',
+          action: 'event-action',
+          label: 'event-label',
+          value: 0,
+          fieldsObject: {
+            dimension1: 'dimension1',
+            metric1: 'metric1',
+            dimension2: 'dimension2',
+          },
+        }))(null, null, null),
+      ];
+
+      window.ga = jest.fn();
+      target(events);
+
+      expect(window.ga.mock.calls[0][1]).toMatchObject({
+        dimension1: 'dimension1',
+        metric1: 'metric1',
+        dimension2: 'dimension2',
+      });
+    });
+  });
+  describe('When you pass the target a pageview with a fieldsObject', () => {
+    test('the properties in the field object are included in the ga pageview hit', () => {
+      const events = [
+        trackPageView(() => ({
+          page: 'page-name',
+          title: 'page-title',
+          location: 'page-url',
+          fieldsObject: {
+            dimension1: 'dimension1',
+            metric1: 'metric1',
+            dimension2: 'dimension2',
+          },
+        }))(null, null, null),
+      ];
+
+      window.ga = jest.fn();
+      target(events);
+
+      expect(window.ga.mock.calls[1][1]).toMatchObject({
+        dimension1: 'dimension1',
+        metric1: 'metric1',
+        dimension2: 'dimension2',
+      });
     });
   });
 });

--- a/packages/google-analytics/src/event-helpers.ts
+++ b/packages/google-analytics/src/event-helpers.ts
@@ -5,11 +5,14 @@ export const trackPageView = (
     page: string;
     title?: string;
     location?: string;
+    fieldsObject?: {
+      [key: string]: any;
+    };
   }>,
   tracker?: string
 ): EventDefinition => (action, prevState, nextState) => {
   const event = eventDef(action, prevState, nextState);
-  const { page, title, location } = event;
+  const { page, title, location, fieldsObject = {} } = event;
 
   return {
     hitType: 'pageview',
@@ -17,6 +20,7 @@ export const trackPageView = (
     page,
     title,
     location,
+    ...fieldsObject,
   };
 };
 
@@ -26,11 +30,14 @@ export const trackEvent = (
     action: string;
     label?: string;
     value?: number;
+    fieldsObject?: {
+      [key: string]: any;
+    };
   }>,
   tracker?: string
 ): EventDefinition => (action, prevState, nextState) => {
   const event = eventDef(action, prevState, nextState);
-  const { category, label, value } = event;
+  const { category, label, value, fieldsObject = {} } = event;
 
   return {
     hitType: 'event',
@@ -39,6 +46,7 @@ export const trackEvent = (
     eventAction: event.action,
     eventLabel: label,
     eventValue: value,
+    ...fieldsObject,
   };
 };
 


### PR DESCRIPTION
Checklist
----

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

 - [x] I have added tests that prove my fix is effective or that my feature works.
 - [ ] I have added all necessary documentation (if appropriate)

What was done
----

These changes adds support for custom dimensions when tracking events and page views in Google Analytics. The API adopted here was directly taken directly from the discussion in #278.


Associated Issues
----
 - Fixes #278 