### PR TITLE
Update error to console.warn

### DIFF
--- a/packages/segment/src/segment.ts
+++ b/packages/segment/src/segment.ts
@@ -5,9 +5,7 @@ const Segment = (): Target => events => {
     return;
   }
   if (!(window as any).analytics) {
-    throw new Error(
-      'window.analytics is not defined, Have you forgotten to include the Segment tracking snippet?'
-    );
+    console.warn('window.analytics is not defined, Have you forgotten to include the Segment tracking snippet?');
   }
   events.forEach(event => {
     switch (event.hitType) {


### PR DESCRIPTION
This should definitely not be throwing an error because of the window.analytics not being defined. When we async load segment and tie this into our redux state it shouldn't break our application. It should provide just a warning. React follow a similar approach.

Checklist
----

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

 - [ ] I have added tests that prove my fix is effective or that my feature works.
 - [ ] I have added all necessary documentation (if appropriate)

What was done
----

_...Describe the fix you made, the feature you built, or the documentation you added_


Associated Issues
----
 - _list any associated issue numbers here_

:heart: Thanks
----
Thanks for taking the time to help out with the project, it's much appreciated :slightly_smiling_face:
