### PR TITLE
Events map symbols

### DIFF
--- a/packages/redux-beacon/src/__tests__/get-events-with-matching-key.test.ts
+++ b/packages/redux-beacon/src/__tests__/get-events-with-matching-key.test.ts
@@ -1,5 +1,7 @@
 import getEventsWithMatchingKey from '../get-events-with-matching-key';
 
+const actionSymbolString = 'actionSymbol';
+const actionSymbol = Symbol('actionSymbol');
 [
   {
     title: 'action type matches a key exactly',
@@ -48,6 +50,16 @@ import getEventsWithMatchingKey from '../get-events-with-matching-key';
     },
     actionType: '[Collection] Add Book Success',
     expected: ['eventDefAddBookSuccess'],
+  },
+  {
+    title: 'action type can be a Symbol',
+    eventsMap: {
+      [actionSymbol]: 'eventDefSymbol',
+      [actionSymbolString]: 'eventDefString',
+      [`Symbol(${actionSymbolString})`]: 'eventDefString',
+    },
+    actionType: actionSymbol,
+    expected: ['eventDefSymbol'],
   },
 ].forEach((scenario, index) => {
   const { title, eventsMap, actionType, expected, only } = scenario;

--- a/packages/redux-beacon/src/get-events-with-matching-key.ts
+++ b/packages/redux-beacon/src/get-events-with-matching-key.ts
@@ -4,7 +4,11 @@ function getEventsWithMatchingKey(
   eventsMap: EventsMap,
   actionType: string
 ): EventDefinition[] {
-  return Object.keys(eventsMap)
+  const objectKeys = Object.keys(eventsMap);
+  const symbolKeys = Object.getOwnPropertySymbols
+    ? Object.getOwnPropertySymbols(eventsMap)
+    : [];
+  return [...objectKeys, ...symbolKeys]
     .filter(key => key === '*' || key === actionType)
     .map(matchingKey => eventsMap[matchingKey]);
 }


### PR DESCRIPTION
Checklist
----

 - [x] I have added tests that prove my fix is effective or that my feature works.
 - [ ] I have added all necessary documentation (if appropriate)

What was done
----

This adds support for matching to actions that are defined by Symbols, rather than simple strings. The only reason the previous implementation didn't work for this use case is because symbol properties aren't returned from `Object.keys`. Making sure that we have those symbol properties when comparing to the actionType fixes the issue with no further complications.

The only gotcha here is that symbols aren't [universally supported](http://kangax.github.io/compat-table/es6/#test-Symbol) yet so I included a [short circuit](https://github.com/rangle/redux-beacon/commit/6b57d68a2d71d4c12bcb37453c5a803eec1c6f58#diff-5f27c92c663e75f4aacfe68f7b1375caR8) in case the required object method isn't available.

I didn't add any additional documentation since I figure most people aren't using redux this way and it kind of behaves the way you would expect it to if you do happen to be. However, I can add some if you would like.


Associated Issues
----
 - _None that I can find_


----
Thanks and let me know if there's anything else that needs to be done! 🍻 
