### PR TITLE
fix issue #333 - Error when trying to track e-commerce items in GA

### DIFF
--- a/packages/google-analytics/src/event-helpers.ts
+++ b/packages/google-analytics/src/event-helpers.ts
@@ -149,12 +149,16 @@ export const trackEcommTransaction = <A = { [key: string]: any }, S = any>(
   };
 };
 
-export const ecommSend = (tracker?: string[] | string) => ({
+export const ecommSend = (
+  tracker?: string[] | string
+): EventDefinition => () => ({
   hitType: 'ecommSend',
   customTrackerId: tracker,
 });
 
-export const ecommClear = (tracker?: string[] | string) => ({
+export const ecommClear = (
+  tracker?: string[] | string
+): EventDefinition => () => ({
   hitType: 'ecommClear',
   customTrackerId: tracker,
 });


### PR DESCRIPTION
Checklist
----
[x] Fix issue #333 - Error when trying to track e-commerce items in GA following documentation

What was done
----

I have changed functions `ecommSend` and `ecommClear` to return type EventDefinition. We don't need any information about action, prevState and nextState to send e-commerce data to GA, so I did not add any additional function parameter to `ecommSend` and `ecommClear` like in other helpers.

Associated Issues
----
#333
