### PR TITLE
Warn instead of Throw on missing GA snippet.

### DIFF
--- a/packages/google-analytics/src/__tests__/__snapshots__/google-analytics.test.ts.snap
+++ b/packages/google-analytics/src/__tests__/__snapshots__/google-analytics.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GoogleAnalytics(events) When window.ga is not defined logs an error informing the developer that no analytics are being tracked 1`] = `""`;

--- a/packages/google-analytics/src/__tests__/__snapshots__/google-analytics.test.ts.snap
+++ b/packages/google-analytics/src/__tests__/__snapshots__/google-analytics.test.ts.snap
@@ -1,3 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GoogleAnalytics(events) When window.ga is not defined logs an error informing the developer that no analytics are being tracked 1`] = `""`;
+exports[`GoogleAnalytics(events) When window.ga is not defined logs an error informing the developer that no analytics are being tracked 1`] = `
+"
+WARN 
+    [@redux-beacon/google-analytics] Analytics are not being tracked, window.ga 
+    is not a function. Please include the Analytics Tag snippet:
+    https://support.google.com/analytics/answer/1008080    
+    "
+`;

--- a/packages/google-analytics/src/__tests__/google-analytics.test.ts
+++ b/packages/google-analytics/src/__tests__/google-analytics.test.ts
@@ -14,10 +14,8 @@ afterEach(() => {
   console.clearHistory();
 });
 
-const target = GoogleAnalytics();
-
 describe('GoogleAnalytics(events)', () => {
-  it('calls window.ga("send", <event>) for each event', () => {
+  it.only('calls window.ga("send", <event>) for each event', () => {
     const events = [
       {
         hitType: 'pageview',
@@ -35,6 +33,9 @@ describe('GoogleAnalytics(events)', () => {
     ];
 
     window.ga = jest.fn();
+
+    const target = GoogleAnalytics();
+
     target(events);
 
     expect(window.ga).toHaveBeenCalledWith('send', events[0]);
@@ -62,6 +63,9 @@ describe('GoogleAnalytics(events)', () => {
       ];
 
       window.ga = jest.fn();
+
+      const target = GoogleAnalytics();
+
       target(events);
 
       expect(window.ga).toHaveBeenCalledWith(
@@ -87,6 +91,9 @@ describe('GoogleAnalytics(events)', () => {
       ];
 
       window.ga = jest.fn();
+
+      const target = GoogleAnalytics();
+
       target(events);
 
       expect(window.ga).toHaveBeenCalledWith('testHub.send', events[0]);
@@ -104,6 +111,9 @@ describe('GoogleAnalytics(events)', () => {
       ];
 
       window.ga = jest.fn();
+
+      const target = GoogleAnalytics();
+
       target(events);
 
       expect(window.ga).toHaveBeenCalledWith('set', 'page', '/home');
@@ -121,6 +131,9 @@ describe('GoogleAnalytics(events)', () => {
       ];
 
       window.ga = jest.fn();
+
+      const target = GoogleAnalytics();
+
       target(events);
 
       const hit = window.ga.mock.calls[1][1];
@@ -150,7 +163,7 @@ describe('GoogleAnalytics(events)', () => {
       expect(console.printHistory()).toMatchSnapshot();
     });
   });
-  
+
   describe('when ga:ecommerce is being used', () => {
     beforeEach(() => {
       window.ga = jest.fn();
@@ -166,6 +179,8 @@ describe('GoogleAnalytics(events)', () => {
           name: itemName,
         },
       ];
+
+      const target = GoogleAnalytics();
 
       target(events);
 
@@ -186,7 +201,10 @@ describe('GoogleAnalytics(events)', () => {
         },
       ];
 
+      const target = GoogleAnalytics();
+
       target(events);
+
       expect(window.ga).toHaveBeenCalledWith('ecommerce:addTransaction', {
         id,
         revenue,
@@ -200,7 +218,10 @@ describe('GoogleAnalytics(events)', () => {
         },
       ];
 
+      const target = GoogleAnalytics();
+
       target(events);
+
       expect(window.ga).toHaveBeenCalledWith('ecommerce:clear');
     });
 
@@ -215,7 +236,10 @@ describe('GoogleAnalytics(events)', () => {
         },
       ];
 
+      const target = GoogleAnalytics();
+
       target(events);
+
       expect(window.ga).toHaveBeenCalledWith(
         `${customTrackerId}.ecommerce:addTransaction`,
         {
@@ -231,7 +255,10 @@ describe('GoogleAnalytics(events)', () => {
         },
       ];
 
+      const target = GoogleAnalytics();
+
       target(events);
+
       expect(window.ga).toHaveBeenCalledWith('ecommerce:send');
     });
   });
@@ -249,7 +276,10 @@ describe('GoogleAnalytics(events)', () => {
         },
       ];
 
+      const target = GoogleAnalytics();
+
       target(events);
+
       expect(window.ga).toHaveBeenCalledWith('ec:clear');
     });
 
@@ -261,7 +291,11 @@ describe('GoogleAnalytics(events)', () => {
             ecommType: 'enhanced',
           },
         ];
+
+        const target = GoogleAnalytics();
+
         target(events);
+
         expect(window.ga).toHaveBeenCalledWith(`ec:${hitType}`, {});
       });
     });
@@ -275,7 +309,10 @@ describe('GoogleAnalytics(events)', () => {
         },
       ];
 
+      const target = GoogleAnalytics();
+
       target(events);
+
       expect(window.ga).toHaveBeenCalledWith('ec:setAction', 'click', {});
     });
   });

--- a/packages/google-analytics/src/__tests__/google-analytics.test.ts
+++ b/packages/google-analytics/src/__tests__/google-analytics.test.ts
@@ -1,7 +1,17 @@
+import * as makeConsoleMock from 'consolemock';
 import GoogleAnalytics from '../';
+
+beforeAll(() => {
+  console = makeConsoleMock(console);
+});
 
 beforeEach(() => {
   window.ga = undefined;
+});
+
+/* tslint:disable: no-console */
+afterEach(() => {
+  console.clearHistory();
 });
 
 const target = GoogleAnalytics();
@@ -119,20 +129,29 @@ describe('GoogleAnalytics(events)', () => {
     });
   });
 
-  describe('When ga is not defined', () => {
-    it('should throw an error informing the user.', () => {
-      const events = [
-        {
-          hitType: 'pageview',
-          page: '/home',
-        },
-      ];
-      expect(() => target(events)).toThrow(
-        'window.ga is not defined, Have you forgotten to include Google Analytics?'
-      );
+  describe('When window.ga is not defined', () => {
+    it('does not throw an error', () => {
+      window.ga = undefined;
+
+      expect(() => GoogleAnalytics('GA_TRACKING_ID')).not.toThrow();
+    });
+    it('does nothing when events are pushed to the target', () => {
+      window.ga = undefined;
+
+      const events = [{ type: 'event', action: 'click' }];
+      const target = GoogleAnalytics('GA_TRACKING_ID');
+
+      expect(() => target(events)).not.toThrow();
+    });
+    it('logs an error informing the developer that no analytics are being tracked', () => {
+      window.gtag = undefined;
+
+      GoogleAnalytics('GA_TRACKING_ID');
+
+      expect(console.printHistory()).toMatchSnapshot();
     });
   });
-
+  
   describe('when ga:ecommerce is being used', () => {
     beforeEach(() => {
       window.ga = jest.fn();

--- a/packages/google-analytics/src/__tests__/google-analytics.test.ts
+++ b/packages/google-analytics/src/__tests__/google-analytics.test.ts
@@ -139,12 +139,11 @@ describe('GoogleAnalytics(events)', () => {
       window.ga = undefined;
 
       const events = [{ type: 'event', action: 'click' }];
-      const target = GoogleAnalytics('GA_TRACKING_ID');
 
-      expect(() => target(events)).not.toThrow();
+      expect(() => GoogleAnalytics('GA_TRACKING_ID')(events)).not.toThrow();
     });
     it('logs an error informing the developer that no analytics are being tracked', () => {
-      window.gtag = undefined;
+      window.ga = undefined;
 
       GoogleAnalytics('GA_TRACKING_ID');
 

--- a/packages/google-analytics/src/google-analytics.ts
+++ b/packages/google-analytics/src/google-analytics.ts
@@ -6,9 +6,12 @@ const GoogleAnalytics = (): Target => events => {
     return;
   }
   if (typeof (window as any).ga !== 'function') {
-    console.warn(
-      'window.ga is not defined, Have you forgotten to include Google Analytics?'
-    );
+    /* tslint:disable: no-console */
+    console.warn(`
+    [@redux-beacon/google-analytics] Analytics are not being tracked, window.ga 
+    is not a function. Please include the Analytics Tag snippet:
+    https://support.google.com/analytics/answer/1008080    
+    `);
     return;
   }
   events.forEach(event => {

--- a/packages/google-analytics/src/google-analytics.ts
+++ b/packages/google-analytics/src/google-analytics.ts
@@ -6,9 +6,10 @@ const GoogleAnalytics = (): Target => events => {
     return;
   }
   if (typeof (window as any).ga !== 'function') {
-    throw new Error(
+    console.warn(
       'window.ga is not defined, Have you forgotten to include Google Analytics?'
     );
+    return;
   }
   events.forEach(event => {
     const customTrackers = event.customTrackerId || event.tracker;

--- a/packages/google-analytics/src/google-analytics.ts
+++ b/packages/google-analytics/src/google-analytics.ts
@@ -1,10 +1,11 @@
 import { Target } from 'redux-beacon';
 import { filterEcommEvents, isEcommEvent, removeKeys } from './utils';
 
-const GoogleAnalytics = (): Target => events => {
+function GoogleAnalytics(): Target {
   if (typeof window === 'undefined') {
-    return;
+    return () => {};
   }
+
   if (typeof (window as any).ga !== 'function') {
     /* tslint:disable: no-console */
     console.warn(`
@@ -12,68 +13,72 @@ const GoogleAnalytics = (): Target => events => {
     is not a function. Please include the Analytics Tag snippet:
     https://support.google.com/analytics/answer/1008080    
     `);
-    return;
+    return () => {};
   }
-  events.forEach(event => {
-    const customTrackers = event.customTrackerId || event.tracker;
-    const trackerIdsRaw = Array.isArray(customTrackers)
-      ? customTrackers
-      : [customTrackers];
 
-    const trackerIds = trackerIdsRaw.map(
-      trackerId => (!!trackerId && !!trackerId.trim() ? `${trackerId}.` : '')
-    );
+  return function target(events) {
+    events.forEach(event => {
+      const customTrackers = event.customTrackerId || event.tracker;
+      const trackerIdsRaw = Array.isArray(customTrackers)
+        ? customTrackers
+        : [customTrackers];
 
-    const ecommPluginType = event.ecommType === 'enhanced' ? 'ec' : 'ecommerce';
+      const trackerIds = trackerIdsRaw.map(
+        trackerId => (!!trackerId && !!trackerId.trim() ? `${trackerId}.` : '')
+      );
 
-    trackerIds.forEach(trackerId => {
-      if (isEcommEvent(event)) {
-        const callEvent = type =>
-          ({
-            addItem: () =>
-              ga(
-                `${trackerId}${ecommPluginType}:addItem`,
-                filterEcommEvents(event)
-              ),
-            addTransaction: () =>
-              ga(
-                `${trackerId}${ecommPluginType}:addTransaction`,
-                filterEcommEvents(event)
-              ),
-            addImpression: () =>
-              ga(
-                `${trackerId}${ecommPluginType}:addImpression`,
-                filterEcommEvents(event)
-              ),
-            addProduct: () =>
-              ga(
-                `${trackerId}${ecommPluginType}:addProduct`,
-                filterEcommEvents(event)
-              ),
-            addPromo: () =>
-              ga(
-                `${trackerId}${ecommPluginType}:addPromo`,
-                filterEcommEvents(event)
-              ),
-            addAction: () =>
-              ga(
-                `${trackerId}${ecommPluginType}:setAction`,
-                event.actionName,
-                filterEcommEvents(event)
-              ),
-            ecommClear: () => ga(`${trackerId}${ecommPluginType}:clear`),
-            ecommSend: () => ga(`${trackerId}${ecommPluginType}:send`),
-          }[type]());
+      const ecommPluginType =
+        event.ecommType === 'enhanced' ? 'ec' : 'ecommerce';
 
-        callEvent(event.hitType);
-      } else {
-        if (event.hitType === 'pageview') {
-          ga(`${trackerId}set`, 'page', event.page);
+      trackerIds.forEach(trackerId => {
+        if (isEcommEvent(event)) {
+          const callEvent = type =>
+            ({
+              addItem: () =>
+                ga(
+                  `${trackerId}${ecommPluginType}:addItem`,
+                  filterEcommEvents(event)
+                ),
+              addTransaction: () =>
+                ga(
+                  `${trackerId}${ecommPluginType}:addTransaction`,
+                  filterEcommEvents(event)
+                ),
+              addImpression: () =>
+                ga(
+                  `${trackerId}${ecommPluginType}:addImpression`,
+                  filterEcommEvents(event)
+                ),
+              addProduct: () =>
+                ga(
+                  `${trackerId}${ecommPluginType}:addProduct`,
+                  filterEcommEvents(event)
+                ),
+              addPromo: () =>
+                ga(
+                  `${trackerId}${ecommPluginType}:addPromo`,
+                  filterEcommEvents(event)
+                ),
+              addAction: () =>
+                ga(
+                  `${trackerId}${ecommPluginType}:setAction`,
+                  event.actionName,
+                  filterEcommEvents(event)
+                ),
+              ecommClear: () => ga(`${trackerId}${ecommPluginType}:clear`),
+              ecommSend: () => ga(`${trackerId}${ecommPluginType}:send`),
+            }[type]());
+
+          callEvent(event.hitType);
+        } else {
+          if (event.hitType === 'pageview') {
+            ga(`${trackerId}set`, 'page', event.page);
+          }
+          ga(`${trackerId}send`, removeKeys(event, ['customTrackerId']));
         }
-        ga(`${trackerId}send`, removeKeys(event, ['customTrackerId']));
-      }
+      });
     });
-  });
-};
+  };
+}
 
 export default GoogleAnalytics;


### PR DESCRIPTION
Throwing an error here breaks subsequent redux store actions in some cases. It should just be a warning as any underlying React app can function without Google Analytics. .....and GA snippets can easily be removed by careless sysadmins.

Checklist
----

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

 - [ ] I have added tests that prove my fix is effective or that my feature works.
 - [ ] I have added all necessary documentation (if appropriate)

What was done
----

Changed `throw` to `console.warn` so this module doesn't break a whole app when GA isn't loaded :-)


Associated Issues
----
N/A

:heart: Thanks
----
Thanks for taking the time to help out with the project, it's much appreciated :slightly_smiling_face:
