### PR TITLE
Support Custom Dimensions and Metrics in google-analytics-gtag target…

### DIFF
--- a/docs/targets/google-analytics-gtag.md
+++ b/docs/targets/google-analytics-gtag.md
@@ -57,6 +57,9 @@ const pageView = trackPageView((action, prevState, nextState) => {
    title: /* (optional) */,
    location: /* (optional) */,
    path: /* (optional) */,
+   fieldsObject: { /* (optional) */
+     [ /* dimension | metric */]: /* value */,
+   },
  };
 }, /* (optional) tracking Id */, /* (optional) tracking Id */, ...);
 ```
@@ -81,6 +84,9 @@ const event = trackEvent((action, prevState, nextState) => {
     action: /* fill me in */,
     label: /* (optional) */,
     value: /* (optional) */,
+    fieldsObject: { /* (optional) */
+      [ /* dimension | metric */]: /* value */,
+    },
   };
 });
 ```

--- a/packages/google-analytics-gtag/src/__tests__/google-analytics-gtag.test.ts
+++ b/packages/google-analytics-gtag/src/__tests__/google-analytics-gtag.test.ts
@@ -1,5 +1,6 @@
 import * as makeConsoleMock from 'consolemock';
 import GoogleAnalyticsGtag from '../';
+import { trackEvent, trackPageView } from '../event-helpers';
 
 beforeAll(() => {
   console = makeConsoleMock(console);
@@ -102,6 +103,30 @@ describe('Page Tracking', () => {
       page_path: '/topics',
     });
   });
+
+  describe('When you pass the target a pageView with a fieldsObject', () => {
+    it('includes the properties in the fieldsObject in the gtag event hit', () => {
+      const events = [
+        trackPageView(() => ({
+          title: 'event-title',
+          location: 'event-location',
+          path: 'event-path',
+          fieldsObject: {
+            dimension1: 'dimension1',
+            metric1: 'metric1',
+          },
+        }))(null, null, null),
+      ];
+
+      const target = GoogleAnalyticsGtag('GA_TRACKING_ID');
+      target(events);
+
+      expect(window.gtag.mock.calls[1][2]).toMatchObject({
+        dimension1: 'dimension1',
+        metric1: 'metric1',
+      });
+    });
+  });
 });
 
 describe('Event Tracking', () => {
@@ -156,6 +181,31 @@ describe('Undefined Event Type', () => {
     target(events);
 
     expect(window.gtag).not.toHaveBeenCalled();
+  });
+});
+
+describe('When you pass the target an event with a fieldsObject', () => {
+  it('includes the properties in the fieldsObject in the gtag event hit', () => {
+    const events = [
+      trackEvent(() => ({
+        category: 'event-category',
+        action: 'event-action',
+        label: 'event-label',
+        value: 0,
+        fieldsObject: {
+          dimension1: 'dimension1',
+          metric1: 'metric1',
+        },
+      }))(null, null, null),
+    ];
+
+    const target = GoogleAnalyticsGtag('GA_TRACKING_ID');
+    target(events);
+
+    expect(window.gtag.mock.calls[1][2]).toMatchObject({
+      dimension1: 'dimension1',
+      metric1: 'metric1',
+    });
   });
 });
 

--- a/packages/google-analytics-gtag/src/event-helpers.ts
+++ b/packages/google-analytics-gtag/src/event-helpers.ts
@@ -5,17 +5,21 @@ export const trackPageView = (
     title?: string;
     location?: string;
     path?: string;
+    fieldsObject?: {
+      [key: string]: any;
+    };
   }>,
   ...trackers: string[]
 ): EventDefinition => (action, prevState, nextState) => {
   const event = eventDef(action, prevState, nextState);
-
+  const { title, location, path, fieldsObject = {} } = event;
   return {
     type: 'page',
     trackingId: trackers,
-    page_title: event.title,
-    page_location: event.location,
-    page_path: event.path,
+    page_title: title,
+    page_location: location,
+    page_path: path,
+    ...fieldsObject,
   };
 };
 
@@ -25,15 +29,20 @@ export const trackEvent = (
     action: string;
     label?: string;
     value?: number;
+    fieldsObject?: {
+      [ket: string]: any;
+    };
   }>
 ): EventDefinition => (action, prevState, nextState) => {
   const event = eventDef(action, prevState, nextState);
+  const { category, label, value, fieldsObject = {} } = event;
 
   return {
     type: 'event',
     action: event.action,
-    event_category: event.category,
-    event_label: event.label,
-    value: event.value,
+    event_category: category,
+    event_label: label,
+    value,
+    ...fieldsObject,
   };
 };


### PR DESCRIPTION
… for pageViews and events

Checklist
----

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

 - [x] I have added tests that prove my fix is effective or that my feature works.
 - [x] I have added all necessary documentation (if appropriate)

What was done
----

Added custom dimensions and metrics as a `fieldsObject` for the `trackEvents` and `trackPageView` functions for `google-analytics-gtag` target.


Associated Issues
----
 - Inspired by https://github.com/rangle/redux-beacon/issues/278
