### PR TITLE
Remove restriction on amplitude-js version

### DIFF
--- a/packages/amplitude/package.json
+++ b/packages/amplitude/package.json
@@ -18,7 +18,7 @@
     "build": "tsc -p tsconfig.build.json"
   },
   "peerDependencies": {
-    "amplitude-js": "^4.1.0",
+    "amplitude-js": ">=4.1.0",
     "redux-beacon": "2.x"
   }
 }


### PR DESCRIPTION
NPM v7 currently returns this error on installation:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: shortcm_frontend_account@1.0.0
npm ERR! Found: amplitude-js@7.4.4
npm ERR! node_modules/amplitude-js
npm ERR!   amplitude-js@"^7.4.1" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer amplitude-js@"^4.1.0" from @redux-beacon/amplitude@1.0.3
npm ERR! node_modules/@redux-beacon/amplitude
npm ERR!   @redux-beacon/amplitude@"^1.0.3" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See /home/kostenko/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/kostenko/.npm/_logs/2021-08-15T09_55_07_290Z-debug.log
```

I don't think there is a need a strict version check for amplitude-js version

Checklist
----

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

 - [ ] I have added tests that prove my fix is effective or that my feature works.
 - [ ] I have added all necessary documentation (if appropriate)

What was done
----

_...Describe the fix you made, the feature you built, or the documentation you added_


Associated Issues
----
 - _list any associated issue numbers here_

:heart: Thanks
----
Thanks for taking the time to help out with the project, it's much appreciated :slightly_smiling_face:
